### PR TITLE
Do not conceal Markdown and JSON

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -342,3 +342,7 @@ nnoremap <leader>rit  :RInlineTemp<cr>
 vnoremap <leader>rrlv :RRenameLocalVariable<cr>
 vnoremap <leader>rriv :RRenameInstanceVariable<cr>
 vnoremap <leader>rem  :RExtractMethod<cr>
+
+" Vim Polyglot
+let g:vim_markdown_conceal = 0
+let g:vim_json_syntax_conceal = 0


### PR DESCRIPTION
It allows to not conceal these kinds of files...

Before:
<img width="1221" alt="Screen Shot 2020-09-29 at 12 46 47" src="https://user-images.githubusercontent.com/173159/94581828-e99e3c00-0251-11eb-9335-8447186d60d9.png">

After:
<img width="1237" alt="Screen Shot 2020-09-29 at 12 46 09" src="https://user-images.githubusercontent.com/173159/94581843-eefb8680-0251-11eb-8feb-fd880fe05bcb.png">
